### PR TITLE
feature/ETHDenver: Extend `NetworkResponseCode`; Added convenient `is…

### DIFF
--- a/Sources/Protocols/NetworkResponse.swift
+++ b/Sources/Protocols/NetworkResponse.swift
@@ -8,15 +8,19 @@
 import Foundation
 
 public enum NetworkResponseCode {
-  case success
-  case notFound
-  case aws_tooManyRequests
+  case success                // 200
+  case accepted               // 202
+  case notFound               // 404
+  case conflict               // 409
+  case aws_tooManyRequests    // 429
   case unknown(Int)
   
   init?(rawValue: Int) {
     switch rawValue {
     case 200:   self = .success
+    case 202:   self = .accepted
     case 404:   self = .notFound
+    case 409:   self = .conflict
     case 429:   self = .aws_tooManyRequests
     default:    self = .unknown(rawValue)
     }
@@ -25,10 +29,16 @@ public enum NetworkResponseCode {
   public var code: Int {
     switch self {
     case .success:              return 200
+    case .accepted:             return 202
     case .notFound:             return 404
+    case .conflict:             return 409
     case .aws_tooManyRequests:  return 429
     case .unknown(let code):    return code
     }
+  }
+  
+  public var isSuccess: Bool {
+    return (200..<300).contains(self.code) // 2xx codes
   }
 }
 

--- a/Sources/Tasks/NetworkTask.swift
+++ b/Sources/Tasks/NetworkTask.swift
@@ -13,11 +13,13 @@ public final class NetworkTask {
   public enum Error: LocalizedError {
     case badIntermediateState
     case code_404_notFound(response: String)
+    case code_409_conflict(response: String)
     case code_429_awsTooManyRequests(response: String)
     case badCode(code: Int, response: String)
     
     init(code: Int, response: String) {
       switch code {
+      case NetworkResponseCode.conflict.code:             self = .code_409_conflict(response: response)
       case NetworkResponseCode.notFound.code:             self = .code_404_notFound(response: response)
       case NetworkResponseCode.aws_tooManyRequests.code:  self = .code_429_awsTooManyRequests(response: response)
       default:                                            self = .badCode(code: code, response: response)
@@ -29,6 +31,7 @@ public final class NetworkTask {
       case .badIntermediateState:                         return "Bad intermediate state"
       case .badCode(let code, let description):           return "\(code): \(description)"
       case .code_404_notFound(let response):              return "404: \(response)"
+      case .code_409_conflict(let response):              return "409: \(response)"
       case .code_429_awsTooManyRequests(let response):    return "429: \(response)"
       }
     }
@@ -80,7 +83,7 @@ public final class NetworkTask {
   }
   
   private func process<R>(networkResponse: NetworkResponse, config: NetworkRequestConfig) async throws -> R {
-    guard case .success = networkResponse.statusCode else {
+    guard networkResponse.statusCode.isSuccess else {
       if let body = networkResponse.data as? Data {
         throw Error(code: networkResponse.statusCode.code, response: String(data: body, encoding: .utf8) ?? "Unknown")
       } else {


### PR DESCRIPTION
…Success` (2xx codes); Extend `NetworkTask.Error`